### PR TITLE
Updating deprecated `createEvent()` to MouseEvent()

### DIFF
--- a/dist/recorder.js
+++ b/dist/recorder.js
@@ -362,10 +362,19 @@ var Recorder = exports.Recorder = function () {
             var url = (window.URL || window.webkitURL).createObjectURL(blob);
             var link = window.document.createElement('a');
             link.href = url;
-            link.download = filename || 'output.wav';
-            var click = document.createEvent("Event");
-            click.initEvent("click", true, true);
-            link.dispatchEvent(click);
+            link.download = filename || new Date().toISOString() + '.wav';
+            var click = new MouseEvent('click', {
+                view: window,
+                bubbles: true,
+                cancelable: true
+            });
+
+            var cancelled = !link.dispatchEvent(click);
+            if (cancelled) {
+                console.log("download cancelled: A handler called preventDefault.");
+            } else {
+                console.log("download successful: None of the handlers called preventDefault");
+            }
         }
     }]);
 

--- a/lib/recorder.js
+++ b/lib/recorder.js
@@ -342,10 +342,19 @@ var Recorder = exports.Recorder = function () {
             var url = (window.URL || window.webkitURL).createObjectURL(blob);
             var link = window.document.createElement('a');
             link.href = url;
-            link.download = filename || 'output.wav';
-            var click = document.createEvent("Event");
-            click.initEvent("click", true, true);
-            link.dispatchEvent(click);
+            link.download = filename || new Date().toISOString() + '.wav';
+            var click = new MouseEvent('click', {
+                view: window,
+                bubbles: true,
+                cancelable: true
+            });
+
+            var cancelled = !link.dispatchEvent(click);
+            if (cancelled) {
+                console.log("download cancelled: A handler called preventDefault.");
+            } else {
+                console.log("download successful: None of the handlers called preventDefault");
+            }
         }
     }]);
 

--- a/src/recorder.js
+++ b/src/recorder.js
@@ -322,10 +322,19 @@ export class Recorder {
         let url = (window.URL || window.webkitURL).createObjectURL(blob);
         let link = window.document.createElement('a');
         link.href = url;
-        link.download = filename || 'output.wav';
-        let click = document.createEvent("Event");
-        click.initEvent("click", true, true);
-        link.dispatchEvent(click);
+        link.download = filename || new Date().toISOString() + '.wav';
+        let click = new MouseEvent('click', {
+          view: window,
+          bubbles: true,
+          cancelable: true
+        });
+
+        let cancelled = !link.dispatchEvent(click);
+        if (cancelled) {
+          console.log("download cancelled: A handler called preventDefault.");
+        } else {
+          console.log("download successful: None of the handlers called preventDefault");
+        }
     }
 }
 


### PR DESCRIPTION
Used for downloading audio as wav files.